### PR TITLE
Use PR title, not commit message

### DIFF
--- a/.github/workflows/lts-branch-create-pull-request.yaml
+++ b/.github/workflows/lts-branch-create-pull-request.yaml
@@ -53,13 +53,6 @@ jobs:
           else
             echo "$BRANCH exists, nothing to do"
           fi
-      - name: Push Commit with Tag Name
-        env:
-          COMMIT_MESSAGE: "@soloio-bot Sync APIs. @tag-name=${{ steps.parse_github_ref.outputs.tag_name }}"
-        run: |
-          git add .
-          git commit -m "$COMMIT_MESSAGE" --allow-empty
-          git push
       - name: Create Pull Request
         uses: repo-sync/pull-request@v2
         with:
@@ -68,4 +61,4 @@ jobs:
           pr_label: "auto-pr"
           pr_allow_empty: true
           github_token: ${{ secrets.SOLO_BOT_REPO_SECRET }}
-          pr_title: "Sync APIs to ${{ steps.parse_github_ref.outputs.tag_name }}"
+          pr_title: "Sync APIs. @tag-name=${{ steps.parse_github_ref.outputs.tag_name }}"

--- a/.github/workflows/lts-branch-tag-commit.yaml
+++ b/.github/workflows/lts-branch-tag-commit.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # The regex of a commit produced by the soloio-bot
-      COMMIT_REGEX: "^.*(@soloio-bot Sync APIs.)+.*$"
+      COMMIT_REGEX: "^.*(Sync APIs.)+.*$"
     steps:
       - name: Cancel Previous Actions
         uses: styfle/cancel-workflow-action@0.4.1


### PR DESCRIPTION
Previously, we relied on the commit message of the gha to determine what the tag name should be. However, since PRs are squashed, the PR Title is what becomes the commit message. 
1. Update the gha that creates PRs to include the appropriate title
2. Update the gha that tags PRs to look for the updated title (ie removed @soloio-bot prefix)