### PR TITLE
Modify GHA ReleaseBranches Regex

### DIFF
--- a/.github/workflows/lts-branch-tag-commit.yaml
+++ b/.github/workflows/lts-branch-tag-commit.yaml
@@ -32,4 +32,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CUSTOM_TAG: ${{ steps.tag_version.outputs.tag_name }}
-          RELEASE_BRANCHES: '.*master$,gloo-v[0-9]*.[0-9]*.x$'
+          RELEASE_BRANCHES: '.*master$,gloo-v[0-9]+\.[0-9]+\.x$'

--- a/.github/workflows/lts-branch-tag-commit.yaml
+++ b/.github/workflows/lts-branch-tag-commit.yaml
@@ -32,4 +32,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CUSTOM_TAG: ${{ steps.tag_version.outputs.tag_name }}
-          RELEASE_BRANCHES: '*master,gloo-**.**.x'
+          RELEASE_BRANCHES: '.*master$,gloo-v[0-9]*.[0-9]*.x$'


### PR DESCRIPTION
On a previous run of the GHA that tags commits on LTS branches (https://github.com/solo-io/solo-apis/runs/3147565462?check_suite_focus=true), the branch was determined to not be a release branch, and therefore a tag was not generated. 

This is because the regex we provided was not accurate. The github action we rely on compares the regex to the branch (https://github.com/anothrNick/github-tag-action/blob/master/entrypoint.sh#L37). The new regex will correct match.