### PR TITLE
Add custom (un)marshal functions for AuthConfig namespacedStatuses

### DIFF
--- a/codegen/gloo.go
+++ b/codegen/gloo.go
@@ -32,14 +32,14 @@ func GlooGroups() []model.Group {
 				protoPackage: "enterprise.gloo.solo.io",
 				goPackage:    "github.com/solo-io/solo-apis/pkg/api/gloo.solo.io/v1/enterprise/options/extauth/v1",
 			},
-		}, []model.CustomTemplates{}),
+		}, GlooCustomTemplates),
 	}
 }
 
 // Gloo resources, backed by solo-kit, support reporting statuses for multiple controllers (1 per namespace)
 // Gloo-Fed resources, backed by skv2, do not yet. To reduce the complexity of the change, we
 // chose to not introduce namespaced statuses support for gloo-fed resources as part of this PR.
-// In order to handle these two cases simultaneously, we define custom status unmarhsallers for Gloo-Fed resources.
+// In order to handle these two cases simultaneously, we define custom status unmarshallers for Gloo-Fed resources.
 
 var GlooCustomTemplates []model.CustomTemplates
 

--- a/hack/post-generate.sh
+++ b/hack/post-generate.sh
@@ -13,3 +13,8 @@ gatewayJsonGenFile="pkg/api/gateway.solo.io/v1/$jsonGenFile"
 if [ -f "$gatewayJsonGenFile" ] ; then
     rm "$gatewayJsonGenFile"
 fi
+
+glooEnterpriseJsonGenFile="pkg/api/enterprise.gloo.solo.io/v1/$jsonGenFile"
+if [ -f "$glooEnterpriseJsonGenFile" ] ; then
+    rm "$glooEnterpriseJsonGenFile"
+fi

--- a/pkg/api/enterprise.gloo.solo.io/v1/gloo_json.gen.go
+++ b/pkg/api/enterprise.gloo.solo.io/v1/gloo_json.gen.go
@@ -20,7 +20,7 @@ var _ = fmt.Errorf
 var _ = math.Inf
 
 var (
-	marshaller   = &skv2jsonpb.Marshaler{}
+	marshaller   = &skv2jsonpb.Marshaler{EnumsAsInts: true}
 	unmarshaller = &jsonpb.Unmarshaler{}
 )
 
@@ -43,5 +43,17 @@ func (this *AuthConfigStatus) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON is a custom unmarshaler for AuthConfigStatus
 func (this *AuthConfigStatus) UnmarshalJSON(b []byte) error {
-	return unmarshaller.Unmarshal(bytes.NewReader(b), this)
+	namespacedStatuses := AuthConfigNamespacedStatuses{}
+	if err := unmarshaller.Unmarshal(bytes.NewReader(b), &namespacedStatuses); err != nil {
+		return unmarshaller.Unmarshal(bytes.NewReader(b), this)
+	}
+
+	for _, status := range namespacedStatuses.GetStatuses() {
+		// take the first status
+		if status != nil {
+			status.DeepCopyInto(this)
+			return nil
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
Add the custom marshal/unmarshal functions to the `AuthConfig` type in order to avoid these errors when trying to read those resources after the `namespacedStatuses` have been reported on them by Edge:

```
E1005 14:22:50.145313       1 reflector.go:138] pkg/mod/k8s.io/client-go@v0.20.4/tools/cache/reflector.go:167: Failed to watch *v1.AuthConfig: failed to list *v1.AuthConfig: v1.AuthConfigList.ListMeta: v1.ListMeta.TypeMeta: Kind: Items: []v1.AuthConfig: v1.AuthConfig.Status: unmarshalerDecoder: unknown field "statuses" in enterprise.gloo.solo.io.AuthConfigStatus, error found in #10 byte of ...|tate":1}}}}],"kind":|..., bigger context ...|":{"gloo-portal":{"reportedBy":"gloo","state":1}}}}],"kind":"AuthConfigList","metadata":{"continue":|...
``` 