### PR TITLE
fix skv2 convert to look for whole words only

### DIFF
--- a/hack/convert/skv2_convert.go
+++ b/hack/convert/skv2_convert.go
@@ -130,9 +130,15 @@ func getRelevantTypes(file []byte, glooGroups []model.Group) []string {
 	return resources
 }
 
-func patchSpecMessage(file []byte, oldMessageBytes []byte) []byte {
-	oldMessageBytes = oldMessageBytes[:len(oldMessageBytes)-1]
-	return bytes.ReplaceAll(file, oldMessageBytes, append(oldMessageBytes, []byte("Spec")...))
+func patchSpecMessage(file []byte, oldMessage []byte) []byte {
+	// get the message without trailing space, e.g. "message MyMessage"
+	// make a copy so we don't modify oldMessage
+	oldMessageNoSpace := make([]byte, len(oldMessage)-1)
+	copy(oldMessageNoSpace, oldMessage)
+
+	// replaces "message MyMessage " with "message MyMessageSpec "
+	newMessage := append(oldMessageNoSpace, []byte("Spec ")...)
+	return bytes.ReplaceAll(file, oldMessage, newMessage)
 }
 
 func appendStatusMessage(fileContents []byte, relevantType string) []byte {


### PR DESCRIPTION
There was a bug where if you had a message in a file (e.g. `GraphQLApiOptions`) that was a substring of the top-level message (e.g. `GraphQLApi`) then the skv2 conversion script would erroneously try to add `Spec` to all instances (e.g. `GraphQLApiSpecOptions`). This fix makes sure to only replace whole words and not substrings.