### PR TITLE
Add a PR template to warn developers about not merging api updates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+# Note to developers
+Generally we only merge API changes that are generated via our automation that is triggered by Gloo releases. 
+
+If you are creating a branch in order to test the impact of an API change on solo-projects or other repo that depends on
+solo-apis, open your PR as a draft or Work in Progress to prevent it from being merged automatically.


### PR DESCRIPTION
In the interest of putting documentation in the places where people need it, adding a note to developers in the PR template to remind them that they likely need to mark any PRs opened in this repo as Work in Progress or draft to avoid having them merge.