### PR TITLE
fix(lts-sync): repair failing repo-sync stage

### DIFF
--- a/.github/workflows/lts-branch-create-pull-request.yaml
+++ b/.github/workflows/lts-branch-create-pull-request.yaml
@@ -40,6 +40,7 @@ jobs:
         run: |
           git config user.name $GIT_USER_NAME
           git config user.email $GIT_USER_EMAIL
+          git config --global --add safe.directory /github/workspace
       - name: Ensure LTS Branch Exists
         env:
           BRANCH: ${{ steps.parse_github_ref.outputs.destination_branch }}


### PR DESCRIPTION
# Note to developers
Generally we only merge API changes that are generated via our automation that is triggered by Gloo releases. 

If you are creating a branch in order to test the impact of an API change on solo-projects or other repo that depends on
solo-apis, open your PR as a draft or Work in Progress to prevent it from being merged automatically.