### PR TITLE
Update hack/sync-gloo-apis to make excluding grpc apis more robust

### DIFF
--- a/hack/sync-gloo-apis.sh
+++ b/hack/sync-gloo-apis.sh
@@ -3,9 +3,12 @@
 set -e
 
 # Sync the proto files from the Gloo Repository checked out at ../gloo
-rsync -ax --exclude 'solo-kit.json' --exclude 'grpc/v*'  ../gloo/projects/gloo/api/  ./api/gloo/gloo
-rmdir api/gloo/gloo/grpc
+# Exclude gloo/api/grpc because we do not currently want to expose any of our grpc apis
+rsync -ax --exclude 'solo-kit.json' --exclude 'grpc'  ../gloo/projects/gloo/api/  ./api/gloo/gloo
 rsync -ax --exclude 'solo-kit.json'  ../gloo/projects/gateway/api/  ./api/gloo/gateway
+
+# Clean up the grpc directory (remove this line if we decide to expose a grpc api
+if [ -d 'api/gloo/gloo/grpc' ]; then rmdir 'api/gloo/gloo/grpc'; fi
 
 # Create Enterprise Gloo directory
 mkdir -p ./api/gloo/enterprise.gloo/v1


### PR DESCRIPTION
Update the script to sync apis to fix this failure: https://github.com/solo-io/gloo/runs/6561709707?check_suite_focus=true#step:9:33

Also this will generally allow us to create a grpc api that does not begin with "v"