### PR TITLE
forcibly migrate go mod prior to post gloo tidy

### DIFF
--- a/hack/sync-gloo-apis.sh
+++ b/hack/sync-gloo-apis.sh
@@ -11,6 +11,8 @@ rsync -ax --exclude 'solo-kit.json'  ../gloo/projects/gateway/api/  ./api/gloo/g
 mkdir -p ./api/gloo/enterprise.gloo/v1
 mv ./api/gloo/gloo/v1/enterprise/options/extauth/v1/extauth.proto ./api/gloo/enterprise.gloo/v1/auth_config.proto
 
+rsync ../gloo/go.mo ./
+
 # Fix paths
 for file in $(find api/gloo -type f | grep ".proto")
 do


### PR DESCRIPTION
We tidy, checkout gloo run make commands that generate and end in tidy.
This means that prior to updating gloo we pull over the mod file and then the final tidy will no longer pull too high of versions