### PR TITLE
build(sync-gloo-apis.sh): added `--delete` flag to rsync

### DIFF
--- a/hack/sync-gloo-apis.sh
+++ b/hack/sync-gloo-apis.sh
@@ -4,8 +4,8 @@ set -e
 
 # Sync the proto files from the Gloo Repository checked out at ../gloo
 # Exclude gloo/api/grpc because we do not currently want to expose any of our grpc apis
-rsync -ax --exclude 'solo-kit.json' --exclude 'grpc'  ../gloo/projects/gloo/api/  ./api/gloo/gloo
-rsync -ax --exclude 'solo-kit.json'  ../gloo/projects/gateway/api/  ./api/gloo/gateway
+rsync -ax --delete --exclude 'solo-kit.json' --exclude 'grpc'  ../gloo/projects/gloo/api/  ./api/gloo/gloo
+rsync -ax --delete --exclude 'solo-kit.json'  ../gloo/projects/gateway/api/  ./api/gloo/gateway
 
 # Clean up the grpc directory (remove this line if we decide to expose a grpc api
 if [ -d 'api/gloo/gloo/grpc' ]; then rmdir 'api/gloo/gloo/grpc'; fi

--- a/hack/sync-gloo-fed-apis.sh
+++ b/hack/sync-gloo-fed-apis.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-rsync -ax ../solo-projects/projects/gloo-fed/api/  ./api/gloo-fed
+rsync --delete -ax ../solo-projects/projects/gloo-fed/api/  ./api/gloo-fed
 
 # Change the paths in the Gloo Fed protos from solo-projects to solo-apis
 for file in $(find api/gloo-fed -type f | grep ".proto")


### PR DESCRIPTION
referencing https://superuser.com/a/156702, we want our start and destination directories to _exactly_ match, cleaning up files that "just so happen" to exist in destination.

Previously, we found that deleting a proto file was not propogated.  Re: it still existed in destination

# Note to developers
Generally we only merge API changes that are generated via our automation that is triggered by Gloo releases. 

If you are creating a branch in order to test the impact of an API change on solo-projects or other repo that depends on
solo-apis, open your PR as a draft or Work in Progress to prevent it from being merged automatically.