### PR TITLE
[v1.10.x] Bump Ubuntu version to 20.04

### DIFF
--- a/.github/workflows/lts-branch-create-pull-request.yaml
+++ b/.github/workflows/lts-branch-create-pull-request.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   create-pr-for-api-sync-branches:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Cancel Previous Actions
         uses: styfle/cancel-workflow-action@0.4.1

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   gen:
     name: Code Gen
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Cancel Previous Runs
       uses: styfle/cancel-workflow-action@0.4.0
@@ -37,7 +37,7 @@ jobs:
 
   test:
     name: Tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.4.0


### PR DESCRIPTION
# Description
 - Fixes an issue which prevented PRs from being auto-generated on 1.10.x branches, due to ubuntu versions being out of date