### PR TITLE
tidy and github actions updates

### DIFF
--- a/.github/workflows/lts-branch-create-pull-request.yaml
+++ b/.github/workflows/lts-branch-create-pull-request.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Cancel Previous Actions
-        uses: styfle/cancel-workflow-action@0.4.1
+        uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}
       - name: Checkout Branch
@@ -31,8 +31,8 @@ jobs:
           DESTINATION_BRANCH=$(echo $GITHUB_BRANCH_NAME | cut -f $DEST_BRANCH_FIELD_NUMBER -d $DELIMITER )
           TAG_NAME=$(echo $GITHUB_BRANCH_NAME | cut -f $TAG_NAME_FIELD_NUMBER -d $DELIMITER )
 
-          echo "::set-output name=destination_branch::$(echo $DESTINATION_BRANCH )"
-          echo "::set-output name=tag_name::$(echo $TAG_NAME )"
+          echo "destination_branch=$DESTINATION_BRANCH" >> $GITHUB_OUTPUT
+          echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
       - name: Setup Git
         env:
           GIT_USER_NAME: soloio-bot

--- a/.github/workflows/lts-branch-tag-commit.yaml
+++ b/.github/workflows/lts-branch-tag-commit.yaml
@@ -13,7 +13,7 @@ jobs:
       COMMIT_REGEX: "^.*(Sync APIs.)+.*$"
     steps:
       - name: Cancel Previous Actions
-        uses: styfle/cancel-workflow-action@0.4.1
+        uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v3
@@ -25,7 +25,7 @@ jobs:
           if [[ $(git log -1 --oneline) =~ ${{ env.COMMIT_REGEX }} ]]; then
             TAG_NAME=$(git log -1 --oneline | awk -F'@tag-name=' '{print $2}' | awk -F' ' '{print $1}')
           fi
-          echo "::set-output name=tag_name::$(echo $TAG_NAME)"
+          echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
       - name: Bump version and push tag
         if: steps.tag_version.outputs.tag_name != ''
         uses: anothrNick/github-tag-action@1.39.0

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -21,7 +21,7 @@ jobs:
         go-version-file: go.mod
       id: go
     - name: Install Protoc
-      uses: solo-io/setup-protoc@master
+      uses: arduino/setup-protoc@master
       with:
         version: '3.6.1'
         repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.4.0
+      uses: styfle/cancel-workflow-action@0.11.0
       with:
         access_token: ${{ github.token }}
     - uses: actions/checkout@v3
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.4.0
+        uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ generate-code:
 	PATH=$(DEPSGOBIN):$$PATH ./hack/post-generate.sh
 
 .PHONY: generate-mocks
-generate-mocks:
+generate-mocks: tidy
 	PATH=$(DEPSGOBIN):$$PATH go generate ./...
 
 .PHONY: tidy


### PR DESCRIPTION
Context: When [testing solo-apis codegen for the DCP APIs](https://github.com/solo-io/solo-apis/pull/830), found that it fails in the middle of `make generate` because `go mod tidy` needs to be called. This is probably due to a new go mod dependency being brought in by the new APIs. Adding a call to `tidy` before `generate-mocks` fixes this issue. Merging this in proactively so that the push-to-solo-apis action doesn't fail when we release gloo with the DCP APIs.

Also updated some deprecated github actions stuff