### PR TITLE
Solo APIs. @tag-name=k8s-1.26

### DIFF
--- a/.github/workflows/lts-branch-tag-commit.yaml
+++ b/.github/workflows/lts-branch-tag-commit.yaml
@@ -1,4 +1,4 @@
-name: Tag Commit on LTS Branch
+name: Tag Commit on gloo-repo-branch Branch
 on:
   push:
     branches:
@@ -30,3 +30,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CUSTOM_TAG: solo-apis-${{ steps.tag_version.outputs.tag_name }}
+          RELEASE_BRANCHES: gloo-repo-branch


### PR DESCRIPTION
- Updating the tag pusher to generate tag based on the base branch `gloo-repo-branch`
- Tagging this in hopes that the action fix will be applied before being ran, so it runs with this fix.