### PR TITLE
Solo APIs. @tag-name=k8s-1.26-bump

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,5 +8,5 @@ After PRs are merged into LTS branches, we:
 1. Push a tag name for that commit
 
 When wanting to release a new tag for this branch, the PR name has to follow the following format: `Solo APIs. @tag-name=<tag>`.
-This will be released as the tag: `solo-apis-<tag>`. We do not follow any strict tagging for this as it is intended for sole use by
-Gloo OSS, but make sure to check for existing tags with `solo-apis-` to avoid collision.
+This will be released as the tag: `sa-<tag>`. We do not follow any strict tagging for this as it is intended for sole use by
+Gloo OSS, but make sure to check for existing tags with `sa-` to avoid collision.

--- a/.github/workflows/lts-branch-tag-commit.yaml
+++ b/.github/workflows/lts-branch-tag-commit.yaml
@@ -29,5 +29,5 @@ jobs:
         uses: anothrNick/github-tag-action@1.26.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CUSTOM_TAG: solo-apis-${{ steps.tag_version.outputs.tag_name }}
+          CUSTOM_TAG: sa-${{ steps.tag_version.outputs.tag_name }}
           RELEASE_BRANCHES: gloo-repo-branch

--- a/.github/workflows/lts-branch-tag-commit.yaml
+++ b/.github/workflows/lts-branch-tag-commit.yaml
@@ -11,10 +11,10 @@ jobs:
       COMMIT_REGEX: "^.*(Solo APIs.)+.*$"
     steps:
       - name: Cancel Previous Actions
-        uses: styfle/cancel-workflow-action@0.4.1
+        uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: '0'
       - name: Parse out tag name from commit message
@@ -26,7 +26,7 @@ jobs:
           echo "::set-output name=tag_name::$(echo $TAG_NAME)"
       - name: Bump version and push tag
         if: steps.tag_version.outputs.tag_name != ''
-        uses: anothrNick/github-tag-action@1.26.0
+        uses: anothrNick/github-tag-action@1.39.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CUSTOM_TAG: sa-${{ steps.tag_version.outputs.tag_name }}


### PR DESCRIPTION
trying to fix the following issue with the tag push action

```
fatal: detected dubious ownership in repository at '/github/workspace'
Is master a match for 
To add an exception for this directory, call:
pre_release = true

	git config --global --add safe.directory /github/workspace
fatal: detected dubious ownership in repository at '/github/workspace'
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
fatal: detected dubious ownership in repository at '/github/workspace'
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
fatal: detected dubious ownership in repository at '/github/workspace'
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
fatal: detected dubious ownership in repository at '/github/workspace'
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
fatal: detected dubious ownership in repository at '/github/workspace'
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
No new commits since previous tag. Skipping...
```