### PR TITLE
main protoc hotfix

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -21,7 +21,7 @@ jobs:
         go-version-file: go.mod
       id: go
     - name: Install Protoc
-      uses: arduino/setup-protoc@master
+      uses: arduino/setup-protoc@v1
       with:
         version: '3.6.1'
         repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Repair reference to arduino/setup-protoc by pinning to v1, rather than master

This change was made because after a [recent upstream change](https://github.com/arduino/setup-protoc/pull/78#issuecomment-1568452913), `master` is no longer a valid pin, causing CI to fail with
```
Run arduino/setup-protoc@master
  with:
    version: 3.6.1
    repo-token: ***
    include-pre-releases: false
Error: Error: unable to get latest version 
```