### PR TITLE
mod: update go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/solo-io/solo-apis
 
-go 1.22.2
+go 1.23.1
 
 replace (
 	github.com/docker/docker => github.com/moby/moby v0.7.3-0.20190826074503-38ab9da00309


### PR DESCRIPTION
https://github.com/solo-io/gloo/commit/b977adc32220df28c0461a0e46e90cac23453551 merged into Gloo OSS. Before we release that version and pull it in here, we need to update the go version